### PR TITLE
docs: fix build instructions pointing to non-existent backend/rust/

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ pip3 install networkx
 # Install the Rust Toolchain
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.bashrc  # this will add `~/.cargo/bin` to path
-cd backend/rust/
 cargo build --release
-cd ../../
 ```
 
 
@@ -35,7 +33,7 @@ cd ../../
 See the [QEC-Playground Documentation: CLI](https://yuewuo.github.io/QEC-Playground/guide/cli.html) for the detailed instructions.
 A brief example use case is below.
 
-Run `cargo run --release -- --help` under `backend/rust/` folder to get all provided commands of backend program.
+Run `cargo run --release -- --help` in the repository root to get all provided commands of backend program.
 The option `--help` prints out the information of this command, which can be helpful to find subcommands as well as to understand the purpose of each option.
 An example output is below.
 

--- a/documentation/src/guide/installation.md
+++ b/documentation/src/guide/installation.md
@@ -51,10 +51,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.bashrc  # this will add `~/.cargo/bin` to path
 ```
 
-After installing the Rust toolchain successfully, you can compile the backend by
+After installing the Rust toolchain successfully, you can compile the backend by running the following in the repository root:
 
 ```bash
-cd backend/rust/
 cargo build --release
 ```
 


### PR DESCRIPTION
The README and installation guide tell users to `cd backend/rust/` before `cargo build --release`, but that directory doesn't exist — `Cargo.toml` and `src/` live at the repository root, so the very first build step fails for new users.

Changes:
- `README.md`: drop the `cd backend/rust/` / `cd ../../` pair; reword the CLI note ("under `backend/rust/` folder" → "in the repository root"). `cargo run --release -- --help` works from the root since `qecp-cli` is the only binary target.
- `documentation/src/guide/installation.md`: same fix in the mdBook source.

Note: the committed rendered docs (`docs/guide/installation.html`) still contain the old path; I left generated output untouched — it will pick up the fix on the next `mdbook build`.