### PR TITLE
fix: correct copy-pasted direction messages in code_builder.rs

### DIFF
--- a/src/code_builder.rs
+++ b/src/code_builder.rs
@@ -121,7 +121,7 @@ impl CodeType {
                     (i - 1, j)
                 }
             }
-            _ => unimplemented!("left position not implemented for this code type, please fill the implementation"),
+            _ => unimplemented!("up position not implemented for this code type, please fill the implementation"),
         }
     }
 
@@ -141,7 +141,7 @@ impl CodeType {
                     (i, j + 1)
                 }
             }
-            _ => unimplemented!("left position not implemented for this code type, please fill the implementation"),
+            _ => unimplemented!("right position not implemented for this code type, please fill the implementation"),
         }
     }
 
@@ -163,7 +163,7 @@ impl CodeType {
                     (i + 1, j)
                 }
             }
-            _ => unimplemented!("left position not implemented for this code type, please fill the implementation"),
+            _ => unimplemented!("down position not implemented for this code type, please fill the implementation"),
         }
     }
 
@@ -185,7 +185,7 @@ impl CodeType {
         self.get_up(i, j, code_size)
     }
 
-    /// convenient call to get diagonal neighbor on the left down
+    /// convenient call to get diagonal neighbor on the right down
     pub fn get_right_down(&self, i: usize, j: usize, code_size: &CodeSize) -> (usize, usize) {
         let (i, j) = self.get_right(i, j, code_size);
         self.get_down(i, j, code_size)


### PR DESCRIPTION
The `unimplemented!()` fallback arms in `get_up()`, `get_right()`, and `get_down()` all say `"left position not implemented..."` — copied from `get_left()`. If one of these ever fires, the panic message points at the wrong function. Also, the doc comment on `get_right_down()` says "left down" (copied from `get_left_down()`).

Changes (strings/comments only, no logic):
- `get_up()`: message → "up position ..."
- `get_right()`: message → "right position ..."
- `get_down()`: message → "down position ..."
- `get_right_down()` doc comment: "left down" → "right down"

`get_left()`'s own message and the `get_left_down()` comment are correct and unchanged. Verified with `cargo check`.