### PR TITLE
fix: remove duplicate author entry in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,6 @@ authors:
   orcid: "https://orcid.org/0000-0002-1400-0402"
 - family-names: "Liyanage"
   given-names: "Namitha"
-- family-names: "Liyanage"
-  given-names: "Namitha"
 title: "QEC-Playground"
 version: 0.1.9
 date-released: 2023-02-10


### PR DESCRIPTION
The "Liyanage / Namitha" author entry appears twice consecutively in `CITATION.cff`. This removes the duplicate (the two entries are identical). Validated that the file still parses as YAML with 2 authors.