### PR TITLE
fix: correct assertion messages and small doc typos

### DIFF
--- a/articles/different_decoders.md
+++ b/articles/different_decoders.md
@@ -25,7 +25,7 @@ Here I give some decoder's **worst case complexity** (their average complexity i
 - C: MWPM decoder (using Blossom V with complexity $O(|V||E|\log{|V|})$):
   - $O(md^2 md^2 d)=O(m^2 d^5)$ when imperfect measurement
   - $O(md^2 d^2)=O(md^4)$ when perfect measurement
-  - $O(md^2 d)=O(md^3)$ when perfect mesurement + biased noise
+  - $O(md^2 d)=O(md^3)$ when perfect measurement + biased noise
 - D: Lin's assumed decoder (which is always $O(N^2)$ complexity, taking no information of noise model):
   - $O(N^2)=O(m^2d^4)$ when imperfect measurement
   - $O(N^2)=O(m^2d^4)$ when perfect measurement

--- a/benchmark/python_interface/README.md
+++ b/benchmark/python_interface/README.md
@@ -4,5 +4,3 @@ It provides an interface to assign noise model with Python and run decoding benc
 
 Example code at `example.py`
 
-## API
-

--- a/src/code_builder.rs
+++ b/src/code_builder.rs
@@ -35,7 +35,7 @@ pub enum CodeType {
     StandardTailoredCode,
     /// noisy measurement rounds (excluding the final perfect measurement cap), +i+j axis code distance, +i-j axis code distance
     RotatedTailoredCode,
-    /// same as RotatedTailoredCode but with first measurement cycle modified for bell state initialization
+    /// same as RotatedTailoredCode but with first measurement cycle modified for Bell state initialization
     RotatedTailoredCodeBellInit,
     /// periodic boundary condition of rotated tailored surface code, code distances must be even number
     PeriodicRotatedTailoredCode,

--- a/src/types.rs
+++ b/src/types.rs
@@ -329,21 +329,21 @@ impl CorrelatedPauliErrorRates {
             self.no_error_probability() >= 0.,
             "sum of error rate should be no more than 1"
         );
-        assert!(self.error_rate_IX >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_IZ >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_IY >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_XI >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_XX >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_XZ >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_XY >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_ZI >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_ZX >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_ZZ >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_ZY >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_YI >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_YX >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_YZ >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_YY >= 0., "error rate should be greater than 0");
+        assert!(self.error_rate_IX >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_IZ >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_IY >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_XI >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_XX >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_XZ >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_XY >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_ZI >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_ZX >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_ZZ >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_ZY >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_YI >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_YX >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_YZ >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_YY >= 0., "error rate should be non-negative");
     }
     pub fn generate_random_error(&self, random_number: f64) -> CorrelatedPauliErrorType {
         let mut random_number = random_number;
@@ -481,9 +481,9 @@ impl CorrelatedErasureErrorRates {
             self.no_error_probability() >= 0.,
             "sum of error rate should be no more than 1"
         );
-        assert!(self.error_rate_IE >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_EI >= 0., "error rate should be greater than 0");
-        assert!(self.error_rate_EE >= 0., "error rate should be greater than 0");
+        assert!(self.error_rate_IE >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_EI >= 0., "error rate should be non-negative");
+        assert!(self.error_rate_EE >= 0., "error rate should be non-negative");
     }
     pub fn generate_random_erasure_error(&self, random_number: f64) -> CorrelatedErasureErrorType {
         let mut random_number = random_number;


### PR DESCRIPTION
String/doc-only fixes:
- 18 assertion messages in `types.rs` said "greater than 0" but the checks are `>= 0.` — now "non-negative"
- `bell state` → `Bell state` in a `code_builder.rs` doc comment
- `mesurement` → `measurement` in `articles/different_decoders.md`
- removed an empty `## API` heading at the end of `benchmark/python_interface/README.md`

No logic changes; `cargo check` passes.